### PR TITLE
Revert "refactor: use async_once_cell instead of lazy_static"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,12 +53,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb07d2053ccdbe10e2af2995a2f116c1330396493dc1269f6a91d0ae82e19704"
 
 [[package]]
-name = "async-once-cell"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f61305cacf1d0c5c9d3ee283d22f8f1f8c743a18ceb44a1b102bd53476c141de"
-
-[[package]]
 name = "async-trait"
 version = "0.1.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -669,7 +663,6 @@ name = "houdini"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "async-once-cell",
  "async-trait",
  "atty",
  "bollard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ path = "src/lib.rs"
 
 [dependencies]
 anyhow = "1.0.58"
-async-once-cell = "0.4.2"
 async-trait = "0.1.56"
 atty = "0.2.14"
 bollard = "0.13.0"
@@ -37,6 +36,7 @@ futures = "0.3.21"
 human-panic = "1.0.3"
 humantime-serde = "1.1.1"
 hyper = "0.14.20"
+lazy_static = "1.4.0"
 log-panics = { version = "2.1.0", features = ["with-backtrace"] }
 nix = { version = "0.24.2", features = ["feature"] }
 serde = { version = "1.0.139", features = ["derive"] }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -83,7 +83,6 @@ impl Cli {
 
                 report
                     .write_to_disk()
-                    .await
                     .context("failed to write report to disk")?;
             }
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,19 +8,15 @@
 
 //! The logic used to configure Houdini.
 
+use anyhow::Result;
+use directories::ProjectDirs;
+use lazy_static::lazy_static;
+use serde::Deserialize;
 use std::path::PathBuf;
 
-use anyhow::Result;
-use async_once_cell::OnceCell;
-use directories::ProjectDirs;
-use serde::Deserialize;
-
-static CONFIG: OnceCell<Config> = OnceCell::new();
-
-pub async fn config<'a>() -> &'a Config {
-    CONFIG
-        .get_or_init(async move { Config::new().expect("failed to initialize config") })
-        .await
+lazy_static! {
+    /// The shared configuration object for Houdini.
+    pub static ref CONFIG: Config = Config::new().expect("Failed to initialize config");
 }
 
 /// The base level config for Houdini.

--- a/src/docker/cmd.rs
+++ b/src/docker/cmd.rs
@@ -117,7 +117,7 @@ impl Command {
     }
 
     async fn exec(&mut self) -> Result<Output> {
-        let client = super::util::client().await?;
+        let client = super::util::client()?;
 
         let opts = CreateExecOptions {
             attach_stdin: Some(false),

--- a/src/docker/container.rs
+++ b/src/docker/container.rs
@@ -18,7 +18,7 @@ use super::{util::client, ImagePullPolicy};
 
 /// Clean up a container by removing it and waiting for it.
 pub async fn reap_container(name: &str) -> Result<()> {
-    let client = client().await?;
+    let client = client()?;
 
     let opts = RemoveContainerOptions {
         v: true,
@@ -55,7 +55,7 @@ pub async fn spawn_container(
         .await
         .context("failed to acquire container image")?;
 
-    let client = client().await?;
+    let client = client()?;
 
     let opts = CreateContainerOptions { name };
     let host_config = HostConfig {
@@ -95,7 +95,7 @@ pub async fn spawn_container(
 
 /// Kill a container.
 pub async fn kill_container(name: &str) -> Result<()> {
-    let client = client().await?;
+    let client = client()?;
 
     client
         .kill_container::<&str>(name, None)

--- a/src/docker/image.rs
+++ b/src/docker/image.rs
@@ -82,7 +82,7 @@ async fn pull_image(
 ) -> Result<()> {
     let tag = image.split_once(':').map(|x| x.1).unwrap_or("latest");
 
-    let client = super::util::client().await?;
+    let client = super::util::client()?;
 
     if client.inspect_image(image).await.is_ok() && !always {
         return Ok(());
@@ -150,7 +150,7 @@ async fn build_image<P: AsRef<Path>>(
     dockerfile: P,
     build_args: &HashMap<String, String>,
 ) -> Result<()> {
-    let client = super::util::client().await?;
+    let client = super::util::client()?;
 
     let tag = image.split_once(':').map(|x| x.1).unwrap_or("latest");
 

--- a/src/docker/util.rs
+++ b/src/docker/util.rs
@@ -10,13 +10,12 @@
 use anyhow::{Context, Result};
 use bollard::{Docker, API_DEFAULT_VERSION};
 
-use crate::config;
+use crate::config::CONFIG;
 
 /// Spawn a bollard::Docker using the configured Unix socket and the default API version.
-pub async fn client() -> Result<Docker> {
+pub fn client() -> Result<Docker> {
     Docker::connect_with_unix(
-        config()
-            .await
+        CONFIG
             .docker
             .socket
             .to_str()

--- a/src/exploits/report.rs
+++ b/src/exploits/report.rs
@@ -17,7 +17,7 @@ use chrono::DateTime;
 use serde::{Deserialize, Serialize};
 use versions::Versioning;
 
-use crate::config;
+use crate::CONFIG;
 
 use super::{
     version::{get_docker_version, get_linux_version, get_runc_version},
@@ -51,13 +51,13 @@ impl Report {
         self.exploits.push(exploit)
     }
 
-    pub async fn write_to_disk(&self) -> Result<()> {
+    pub fn write_to_disk(&self) -> Result<()> {
         let mut s = DefaultHasher::new();
         self.date.hash(&mut s);
         let hash = s.finish();
 
         let filename = format!("report.{}.json", hash);
-        let path = config().await.reports.dir.join(filename);
+        let path = CONFIG.reports.dir.join(filename);
 
         let file =
             std::fs::File::create(&path).context(format!("failed to open file {:?}", &path))?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,5 +18,5 @@ pub mod config;
 pub mod docker;
 pub mod logging;
 
-pub use crate::config::config;
+pub use crate::config::CONFIG;
 pub use cli::Cli;

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -8,7 +8,7 @@
 
 //! This module contains helper functions to set up logging for Houdini.
 
-use crate::{cli, config};
+use crate::{cli, CONFIG};
 use anyhow::Result;
 use clap_derive::ArgEnum;
 use std::{ffi::OsString, fmt::Display, path::PathBuf};
@@ -56,9 +56,9 @@ impl LevelFilterLayer {
 
     // TODO: Allow this to be dead code for now. Will be used later.
     #[allow(dead_code)]
-    pub async fn from_cfg() -> Self {
+    pub fn from_cfg() -> Self {
         Self {
-            level: config().await.log.level.into(),
+            level: CONFIG.log.level.into(),
         }
     }
 }
@@ -73,8 +73,8 @@ impl<S: tracing::Subscriber> Layer<S> for LevelFilterLayer {
     }
 }
 
-async fn get_log_file() -> Result<(Option<PathBuf>, Option<OsString>)> {
-    let file = &config().await.log.file;
+fn get_log_file() -> Result<(Option<PathBuf>, Option<OsString>)> {
+    let file = &CONFIG.log.file;
     let file = match file {
         Some(f) => f,
         None => return Ok((None, None)),
@@ -90,8 +90,8 @@ async fn get_log_file() -> Result<(Option<PathBuf>, Option<OsString>)> {
     Ok((Some(log_dir.to_owned()), Some(log_file.to_owned())))
 }
 
-async fn init_human(args: &cli::Cli) -> Result<Option<WorkerGuard>> {
-    let (log_dir, log_file) = get_log_file().await?;
+fn init_human(args: &cli::Cli) -> Result<Option<WorkerGuard>> {
+    let (log_dir, log_file) = get_log_file()?;
 
     let (file_appender, guard) = if let (Some(log_dir), Some(log_file)) = (log_dir, log_file) {
         let file_appender = tracing_appender::rolling::daily(log_dir, log_file);
@@ -120,8 +120,8 @@ async fn init_human(args: &cli::Cli) -> Result<Option<WorkerGuard>> {
     Ok(guard)
 }
 
-async fn init_json(args: &cli::Cli) -> Result<Option<WorkerGuard>> {
-    let (log_dir, log_file) = get_log_file().await?;
+fn init_json(args: &cli::Cli) -> Result<Option<WorkerGuard>> {
+    let (log_dir, log_file) = get_log_file()?;
 
     let (file_appender, guard) = if let (Some(log_dir), Some(log_file)) = (log_dir, log_file) {
         let file_appender = tracing_appender::rolling::daily(log_dir, log_file);
@@ -150,9 +150,8 @@ async fn init_json(args: &cli::Cli) -> Result<Option<WorkerGuard>> {
 
     Ok(guard)
 }
-
-async fn init_compact(args: &cli::Cli) -> Result<Option<WorkerGuard>> {
-    let (log_dir, log_file) = get_log_file().await?;
+fn init_compact(args: &cli::Cli) -> Result<Option<WorkerGuard>> {
+    let (log_dir, log_file) = get_log_file()?;
 
     let (file_appender, guard) = if let (Some(log_dir), Some(log_file)) = (log_dir, log_file) {
         let file_appender = tracing_appender::rolling::daily(log_dir, log_file);
@@ -181,9 +180,8 @@ async fn init_compact(args: &cli::Cli) -> Result<Option<WorkerGuard>> {
 
     Ok(guard)
 }
-
-async fn init_pretty(args: &cli::Cli) -> Result<Option<WorkerGuard>> {
-    let (log_dir, log_file) = get_log_file().await?;
+fn init_pretty(args: &cli::Cli) -> Result<Option<WorkerGuard>> {
+    let (log_dir, log_file) = get_log_file()?;
 
     let (file_appender, guard) = if let (Some(log_dir), Some(log_file)) = (log_dir, log_file) {
         let file_appender = tracing_appender::rolling::daily(log_dir, log_file);
@@ -214,7 +212,7 @@ async fn init_pretty(args: &cli::Cli) -> Result<Option<WorkerGuard>> {
 }
 
 /// Initialize the logger by setting the right subscriber.
-pub async fn init(args: &cli::Cli) -> Result<Option<WorkerGuard>> {
+pub fn init(args: &cli::Cli) -> Result<Option<WorkerGuard>> {
     let tracing_format = match args.format {
         LoggingFormat::Auto => {
             if atty::is(atty::Stream::Stderr) {
@@ -228,10 +226,10 @@ pub async fn init(args: &cli::Cli) -> Result<Option<WorkerGuard>> {
 
     let guard = match tracing_format {
         LoggingFormat::Auto => unreachable!(),
-        LoggingFormat::Json => init_json(args).await?,
-        LoggingFormat::Pretty => init_pretty(args).await?,
-        LoggingFormat::Full => init_human(args).await?,
-        LoggingFormat::Compact => init_compact(args).await?,
+        LoggingFormat::Json => init_json(args)?,
+        LoggingFormat::Pretty => init_pretty(args)?,
+        LoggingFormat::Full => init_human(args)?,
+        LoggingFormat::Compact => init_compact(args)?,
     };
 
     tracing_log::LogTracer::init()?;


### PR DESCRIPTION
This was creating problems around tagging lots of functions as async and it's not worth
the headache. So let's revert. once_cell was a nice pipe dream, oh well.

This reverts commit e18d40bd12665664e609e6aeb03be03c6dc656f0.

Signed-off-by: William Findlay <will@isovalent.com>